### PR TITLE
adds filter and enable flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,10 @@ class ServerlessPlugin {
 
   appendEventsToTargetFunction() {
     if (this.targetConfigDefined() && this.targetExists()) {
-      const filter = this.filterConfig()
+      const defaultFilter = this.filterConfig()
       const newEvents = this.nonTargetFns().map(function(fn) {
         const sourceLogGeroup = '/aws/lambda/'+fn.name
+        const filter = getFilter.call(fn) || defaultFilter
         if (filter) {
           return { cloudwatchLog: { logGroup: sourceLogGeroup, filter: filter } }
         } else {
@@ -49,6 +50,10 @@ class ServerlessPlugin {
     const target = this.targetFn()
     return Object.values(fns).filter((fn) => fn.name != target.name)
   }
+}
+
+function getFilter() {
+  return dig(this, 'logfunnel.filter')
 }
 
 module.exports = ServerlessPlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-log-funnel",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Forward logs events to a lambda defined in the same servereless deploy.",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ functions:
   logHandler:                           # required
     handler: myLogHandler
 ```
-will configure logfunnel to receive cloudwatch events from fnA and fnB
+will configure `logHandler` to receive cloudwatch events from `fnA` and `fnB`
 
 `custom.logfunnel.targetfn.someFunctionName` is required and must match `functions.someFunctionName`
 

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ functions:
     logHandler:
       enabled: true/false               # optional, defaults to custom.logfunnel.enabled
       filter: '{ $.something = stuff }' # optional, defaults to custom.logfunnel.filter
-  logHandler:                           # required
+  logHandler:                           # required, custom.logfunnel.targetfn should match this
     handler: myLogHandler
 ```
 will configure `logHandler` to receive cloudwatch events from `fnA` and `fnB`

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,30 @@
+# Serverless Log Funnel
+
+Forwards log events to another fuction defined in the same serverless deploy
+
+### Usage
+
 The following configuration in your `serverless.yml`
 ```
 custom:
   logfunnel:
-    targetfn: logfunnel
+    targetfn: logHandler                # must match functions.value
+    enabled: true/false                 # optional, defaults to true
+    filter:  '{ $.something = stuff }'  # optional, defaults to no filter and everything is forwarded
 
 functions:
   fnA:
     handler: foo
   fnB:
     handler: bar
-  logfunnel:
-    handler: funnel
+    logHandler:
+      enabled: true/false               # optional, defaults to custom.logfunnel.enabled
+      filter: '{ $.something = stuff }' # optional, defaults to custom.logfunnel.filter
+  logHandler:                           # must match custom.logfunnel.targetfn
+    handler: myLogHandler
 ```
 will configure logfunnel to receive cloudwatch events from fnA and fnB
+
+### Testing
+
+`npm test`

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ The following configuration in your `serverless.yml`
 ```
 custom:
   logfunnel:
-    targetfn: logHandler                # must match functions.value
+    targetfn: logHandler                # required
     enabled: true/false                 # optional, defaults to true
     filter:  '{ $.something = stuff }'  # optional, defaults to no filter and everything is forwarded
 
@@ -20,10 +20,12 @@ functions:
     logHandler:
       enabled: true/false               # optional, defaults to custom.logfunnel.enabled
       filter: '{ $.something = stuff }' # optional, defaults to custom.logfunnel.filter
-  logHandler:                           # must match custom.logfunnel.targetfn
+  logHandler:                           # required
     handler: myLogHandler
 ```
 will configure logfunnel to receive cloudwatch events from fnA and fnB
+
+`custom.logfunnel.targetfn.someFunctionName` is required and must match `functions.someFunctionName`
 
 ### Testing
 

--- a/test-helper.js
+++ b/test-helper.js
@@ -1,7 +1,7 @@
 const ts = module.exports = {
   assert: function(t, msg) {
     if (t) { return }
-    throw msg
+    throw new Error(msg)
   },
 
   "$": function(given){
@@ -21,5 +21,39 @@ const ts = module.exports = {
         equals ? '' : [subject, obj].map((a) => JSON.stringify(a, null, 2)).join("\ndoes not equal\n"),
       ]
     }
+  },
+
+  test: function(module) {
+    const tests = Object.keys(module.exports).filter(fnName => fnName.startsWith('test'))
+    const failures = []
+    const dots = []
+    tests.forEach((t) => {
+      try {
+        module.exports[t]()
+        dots.push('.')
+      } catch (e) {
+        var msg
+        if (typeof err === 'error') {
+          msg = e
+        } else {
+          msg = e
+        }
+        dots.push('x')
+        failures.push({
+          test: t,
+          msg: msg,
+        })
+      }
+      process.stderr.write(dots.join('')+'\r')
+      if(failures.length) {
+        process.nextTick(function(){
+          console.log('\n\nfailures:\n')
+          failures.forEach((f) => {
+            console.log('test', '"'+f.test+'"', 'failed with:\n', f.msg, '\n')
+          })
+          process.exit(1)
+        })
+      }
+    })
   }
 }

--- a/test.js
+++ b/test.js
@@ -76,6 +76,36 @@ module.exports = {
     eventAdder.appendEventsToTargetFunction()
     $(actualSls).should(equal(expectedSls))
   },
+  testEnabledByDefaultWithDisableOverride: function() {
+    const actualSls = slsConfig()
+    actualSls.service.custom.logfunnel = { target: 'myFunnel' }
+    actualSls.service.functions.foofn.logfunnel = { enabled: false }
+
+    const expectedSls = deepCopy(actualSls)
+    expectedSls.service.functions.myFunnel.events = [
+      { cloudwatchLog: '/aws/lambda/projectname-stage-barfn' },
+    ]
+
+    const eventAdder = new plugin(actualSls)
+
+    eventAdder.appendEventsToTargetFunction()
+    $(actualSls).should(equal(expectedSls))
+  },
+  testDisableByDefaultWithEnableOverride: function() {
+    const actualSls = slsConfig()
+    actualSls.service.custom.logfunnel = { target: 'myFunnel', enabled: false}
+    actualSls.service.functions.foofn.logfunnel = { enabled: true }
+
+    const expectedSls = deepCopy(actualSls)
+    expectedSls.service.functions.myFunnel.events = [
+      { cloudwatchLog: '/aws/lambda/projectname-stage-foofn' },
+    ]
+
+    const eventAdder = new plugin(actualSls)
+
+    eventAdder.appendEventsToTargetFunction()
+    $(actualSls).should(equal(expectedSls))
+  },
   testDig: function() {
     const foo = { bar: { baz: { bing: 5 } } }
     $(dig(foo, 'bar.baz.bing')).should(equal(5))


### PR DESCRIPTION
Adds two customizations:
- `filter` defaults to no filter (forward everything)
- `enabled` defaults to true

Config defaults to the serverless file's `custom.logfunnel.*` but can be overridden by individual functions by defining `functions.foo.logfunnel.*`